### PR TITLE
Implements `Object#in?`

### DIFF
--- a/motion/core_ext/object/inclusion.rb
+++ b/motion/core_ext/object/inclusion.rb
@@ -1,0 +1,16 @@
+class Object
+  # Returns true if this object is included in the argument(s). Argument must be
+  # any object which responds to +#include?+ or optionally, multiple arguments
+  # can be passed in. Usage:
+  #
+  #   characters = ['Konata', 'Kagami', 'Tsukasa']
+  #   'Konata'.in?(characters) # => true
+  #
+  # This will throw an ArgumentError it doesn't respond to +#include?+.
+  def __in_workaround(args)
+    args.include?(self)
+  rescue NoMethodError
+    raise ArgumentError.new("The parameter passed to #in? must respond to #include?")
+  end
+  alias in? __in_workaround
+end

--- a/spec/motion-support/core_ext/object/inclusion_spec.rb
+++ b/spec/motion-support/core_ext/object/inclusion_spec.rb
@@ -1,0 +1,34 @@
+class LifeUniverseAndEverything
+  def include?(obj)
+    obj == 42
+  end
+end
+
+
+describe 'array' do
+  describe "in?" do
+    it "should support arrays" do
+      1.in?([1,2,3]).should == true
+      0.in?([1,2,3]).should == false
+    end
+
+    it "should support hashes" do
+      :a.in?({a:1,b:2,c:3}).should == true
+      1.in?({a:1,b:2,c:3}).should == false
+    end
+
+    it "should support ranges" do
+      1.in?(1..3).should == true
+      0.in?(1..3).should == false
+    end
+
+    it "should support strings" do
+      'a'.in?("apple").should == true
+    end
+
+    it "should support anything that implements `include?`" do
+      42.in?(LifeUniverseAndEverything.new).should == true
+      0.in?(LifeUniverseAndEverything.new).should == false
+    end
+  end
+end


### PR DESCRIPTION
I ran into the same error that you did, the weird 'specs' bug.  I got around it by using an alias.

I implemented the _original_ version of `in?`, see these conversations:

https://github.com/rails/rails/pull/258
https://github.com/rubymotion/sugarcube/issues/76
https://github.com/rails/rails/pull/10394
