### PR TITLE
Squash RM compliant that symbolize_keys!/deep_symbolize_keys! ...

### DIFF
--- a/motion/hash_with_indifferent_access.rb
+++ b/motion/hash_with_indifferent_access.rb
@@ -219,8 +219,8 @@ module MotionSupport
     def deep_stringify_keys!; self end
     def stringify_keys; dup end
     def deep_stringify_keys; dup end
-    undef :symbolize_keys!
-    undef :deep_symbolize_keys!
+    undef :symbolize_keys! if respond_to?(:symbolize_keys!)
+    undef :deep_symbolize_keys! if respond_to?(:deep_symbolize_keys!)
     def symbolize_keys; to_hash.symbolize_keys end
     def deep_symbolize_keys; to_hash.deep_symbolize_keys end
     def to_options!; self end


### PR DESCRIPTION
...fined

Similar to previous fix.
