### PR TITLE
Fix docs for `Object#in?`.

### DIFF
--- a/motion/core_ext/object/inclusion.rb
+++ b/motion/core_ext/object/inclusion.rb
@@ -1,7 +1,6 @@
 class Object
   # Returns true if this object is included in the argument(s). Argument must be
-  # any object which responds to +#include?+ or optionally, multiple arguments
-  # can be passed in. Usage:
+  # any object which responds to +#include?+. Usage:
   #
   #   characters = ['Konata', 'Kagami', 'Tsukasa']
   #   'Konata'.in?(characters) # => true


### PR DESCRIPTION
The comment said that you can optionally pass multiple arguments. The code
doesn't allow this, so I fixed the comment.

To be clear, in case there is pushback: the code was correct and the
comment was wrong.  `Object#in?` should definitely not allow multiple
arguments, because that would make its contract ambiguous. And an
ambiguous contract is worse than useless. People who call it will get
unpredictable behavior.

See related discussions in ActiveSupport, going back to when I first
added `Object#in?` to Rails:
- https://github.com/rails/rails/pull/10394
- https://github.com/rails/rails/pull/258#issuecomment-985570
- https://rails.lighthouseapp.com/projects/8994/tickets/6321#ticket-6321-5
- https://github.com/rails/rails/pull/258#issuecomment-986523
