### PR TITLE
Hash#deep_transform_keys maps over array values

### DIFF
--- a/motion/core_ext/hash/keys.rb
+++ b/motion/core_ext/hash/keys.rb
@@ -82,7 +82,13 @@ class Hash
   def deep_transform_keys(&block)
     result = {}
     each do |key, value|
-      result[yield(key)] = value.is_a?(Hash) ? value.deep_transform_keys(&block) : value
+      result[yield(key)] = if value.is_a?(Hash)
+        value.deep_transform_keys(&block)
+      elsif value.is_a?(Array)
+        value.map { |v| v.is_a?(Hash) ? v.deep_transform_keys(&block) : v }
+      else
+       value
+      end
     end
     result
   end
@@ -93,7 +99,13 @@ class Hash
   def deep_transform_keys!(&block)
     keys.each do |key|
       value = delete(key)
-      self[yield(key)] = value.is_a?(Hash) ? value.deep_transform_keys!(&block) : value
+      self[yield(key)] = if value.is_a?(Hash)
+        value.deep_transform_keys(&block)
+      elsif value.is_a?(Array)
+        value.map { |v| v.is_a?(Hash) ? v.deep_transform_keys(&block) : v }
+      else
+       value
+      end
     end
     self
   end

--- a/spec/motion-support/core_ext/hash/key_spec.rb
+++ b/spec/motion-support/core_ext/hash/key_spec.rb
@@ -13,6 +13,8 @@ describe "Hash" do
       @nested_illegal_symbols = { [] => { [] => 3} }
       @upcase_strings = { 'A' => 1, 'B' => 2 }
       @nested_upcase_strings = { 'A' => { 'B' => { 'C' => 3 } } }
+      @nested_array_symbols = { :a => [ { :a => 1 }, { :b => 2 } ] }
+      @nested_array_strings = { 'a' => [ { 'a' => 1 }, { 'b' => 2 } ] }
     end
     
     it "should have all key methods defined on literal hash" do
@@ -120,6 +122,7 @@ describe "Hash" do
         @nested_symbols.deep_symbolize_keys.should == @nested_symbols
         @nested_strings.deep_symbolize_keys.should == @nested_symbols
         @nested_mixed.deep_symbolize_keys.should == @nested_symbols
+        @nested_array_strings.deep_symbolize_keys.should == @nested_array_symbols
       end
       
       it "should not mutate" do
@@ -159,6 +162,7 @@ describe "Hash" do
         @nested_symbols.deep_dup.deep_symbolize_keys!.should == @nested_symbols
         @nested_strings.deep_dup.deep_symbolize_keys!.should == @nested_symbols
         @nested_mixed.deep_dup.deep_symbolize_keys!.should == @nested_symbols
+        @nested_array_strings.deep_symbolize_keys!.should == @nested_array_symbols
       end
       
       it "should mutate" do
@@ -188,6 +192,7 @@ describe "Hash" do
         @nested_symbols.deep_stringify_keys.should == @nested_strings
         @nested_strings.deep_stringify_keys.should == @nested_strings
         @nested_mixed.deep_stringify_keys.should == @nested_strings
+        @nested_array_symbols.deep_stringify_keys.should == @nested_array_strings
       end
       
       it "should not mutate" do
@@ -217,6 +222,7 @@ describe "Hash" do
         @nested_symbols.deep_dup.deep_stringify_keys!.should == @nested_strings
         @nested_strings.deep_dup.deep_stringify_keys!.should == @nested_strings
         @nested_mixed.deep_dup.deep_stringify_keys!.should == @nested_strings
+        @nested_array_symbols.deep_stringify_keys!.should == @nested_array_strings
       end
       
       it "should mutate" do


### PR DESCRIPTION
This ensures that hashes embedded in arrays are also transformed which intuitively is how this feature should behave.
