### PR TITLE
Removes warning regarding app.detect_dependecies

### DIFF
--- a/lib/motion-support.rb
+++ b/lib/motion-support.rb
@@ -1,5 +1,3 @@
 require 'motion-require'
 
 Motion::Require.all(Dir.glob(File.expand_path('../../motion/**/*.rb', __FILE__)))
-
-at_exit { puts "\nWARNING: Automatic dependency detection does not work with motion-support. Turn it off in your Rakefile:\n\n  app.detect_dependencies = false\n\n" if Motion::Project::App.config.detect_dependencies }


### PR DESCRIPTION
As discussed in https://github.com/tkadauke/motion-support/commit/a0a640db2f39d3dbb19985efb53385b15d59314a#commitcomment-5754306 motion-support seems to work just fine even with detect_dependencies set to true, and some apps won't build at all when set to false.
