### PR TITLE
Add travis build file and badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: objective-c
+
+osx_image: xcode7.1
+
+script: bundle exec rake spec

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # MotionSupport
+[![Build Status](https://travis-ci.org/rubymotion/motion-support.svg?branch=master)](https://travis-ci.org/rubymotion/motion-support)
 
 This is a port of the parts of ActiveSupport that make sense for RubyMotion.
 
@@ -170,7 +171,7 @@ module Mod
   mattr_accessor :foo, :bar
   attr_internal :baz
   delegate :boo, :to => :foo
-  
+
   remove_method :baz
 end
 ```


### PR DESCRIPTION
Automate builds so that no bad code gets shipped (there are currently 4 failing specs).

Ideally this would be set up with automated deploys on tagged commits:
http://docs.travis-ci.com/user/deployment/rubygems/