### PR TITLE
fix specs

### DIFF
--- a/motion/core_ext/big_decimal.rb
+++ b/motion/core_ext/big_decimal.rb
@@ -1,0 +1,8 @@
+class BigDecimal
+
+  # Returns an exact copy of self
+  def dup
+    self.class.new(self)
+  end
+
+end

--- a/spec/motion-support/core_ext/string/filter_spec.rb
+++ b/spec/motion-support/core_ext/string/filter_spec.rb
@@ -5,10 +5,10 @@ describe "String" do
         @original = %{\u180E\u180E A string surrounded by unicode mongolian vowel separators,
           with tabs(\t\t), newlines(\n\n), unicode nextlines(\u0085\u0085) and many spaces(  ). \u180E\u180E}
 
-        @expected = "A string surrounded by unicode mongolian vowel separators, " +
-          "with tabs( ), newlines( ), unicode nextlines( ) and many spaces( )."
+        @expected = "\u180E\u180E A string surrounded by unicode mongolian vowel separators, " +
+          "with tabs( ), newlines( ), unicode nextlines( ) and many spaces( ). \u180E\u180E"
       end
-      
+
       it "should squish string" do
         @original.squish.should == @expected
         @original.should.not == @expected
@@ -19,26 +19,26 @@ describe "String" do
         @original.should == @expected
       end
     end
-    
+
     describe "truncate" do
       it "should truncate string" do
         "Hello World!".truncate(12).should == "Hello World!"
         "Hello World!!".truncate(12).should == "Hello Wor..."
       end
-      
+
       it "should truncate with omission and seperator" do
         "Hello World!".truncate(10, :omission => "[...]").should == "Hello[...]"
         "Hello Big World!".truncate(13, :omission => "[...]", :separator => ' ').should == "Hello[...]"
         "Hello Big World!".truncate(14, :omission => "[...]", :separator => ' ').should == "Hello Big[...]"
         "Hello Big World!".truncate(15, :omission => "[...]", :separator => ' ').should == "Hello Big[...]"
       end
-      
+
       it "should truncate with omission and regexp seperator" do
         "Hello Big World!".truncate(13, :omission => "[...]", :separator => /\s/).should == "Hello[...]"
         "Hello Big World!".truncate(14, :omission => "[...]", :separator => /\s/).should == "Hello Big[...]"
         "Hello Big World!".truncate(15, :omission => "[...]", :separator => /\s/).should == "Hello Big[...]"
       end
-      
+
       it "should truncate multibyte" do
         "\354\225\204\353\246\254\353\236\221 \354\225\204\353\246\254 \354\225\204\353\235\274\353\246\254\354\230\244".force_encoding(Encoding::UTF_8).truncate(10).should ==
           "\354\225\204\353\246\254\353\236\221 \354\225\204\353\246\254 ...".force_encoding(Encoding::UTF_8)

--- a/spec/motion-support/core_ext/time/conversion_spec.rb
+++ b/spec/motion-support/core_ext/time/conversion_spec.rb
@@ -4,45 +4,44 @@ describe "Time" do
       before do
         @time = Time.utc(2005, 2, 21, 17, 44, 30.12345678901)
       end
-      
+
       it "should use default conversion if no parameter is given" do
         @time.to_s.should == @time.to_default_s
       end
-      
+
       it "should use default conversion if parameter is unknown" do
         @time.to_s(:doesnt_exist).should == @time.to_default_s
       end
-      
+
       it "should convert to db format" do
         @time.to_s(:db).should == "2005-02-21 17:44:30"
       end
-      
+
       it "should convert to short format" do
         @time.to_s(:short).should == "21 Feb 17:44"
       end
-      
+
       it "should convert to time format" do
         @time.to_s(:time).should == "17:44"
       end
-      
+
       it "should convert to number format" do
         @time.to_s(:number).should == "20050221174430"
       end
-      
+
       it "should convert to nsec format" do
-        @time.to_s(:nsec).should == "20050221174430123451232"
-        # Hmm. Looks like RubyMotion has an issue with nanosecs in string time formatting. It should actually be "20050221174430123456789"
+        @time.to_s(:nsec).should == "20050221174430123456789"
       end
-      
+
       it "should convert to long format" do
         @time.to_s(:long).should == "February 21, 2005 17:44"
       end
-      
+
       it "should convert to long_ordinal format" do
         @time.to_s(:long_ordinal).should == "February 21st, 2005 17:44"
       end
     end
-    
+
     describe "custom date format" do
       it "should convert to custom format" do
         Time::DATE_FORMATS[:custom] = '%Y%m%d%H%M%S'


### PR DESCRIPTION
I noticed that the build wasn't green.

Some points:
* mongolian vowel separators - they are not filtered out by `squish`. This is also the same in MRI Ruby.
* I monkey-patched BigDecimal to be duplicable. In ruby you can dup it.
* `should convert to nsec format` was already working properly.