### PR TITLE
Add ISO8601 support

### DIFF
--- a/motion/core_ext/date/conversions.rb
+++ b/motion/core_ext/date/conversions.rb
@@ -8,8 +8,14 @@ class Date
       day_format = MotionSupport::Inflector.ordinalize(date.day)
       date.strftime("%B #{day_format}, %Y") # => "April 25th, 2007"
     },
-    :rfc822       => '%e %b %Y'
+    :rfc822       => '%e %b %Y',
+    :iso8601      => '%Y-%m-%d',
+    :xmlschema    => '%Y-%m-%dT00:00:00Z'
   }
+
+  def iso8601
+    strftime DATE_FORMATS[:iso8601]
+  end
 
   # Convert to a formatted string. See DATE_FORMATS for predefined formats.
   #
@@ -51,4 +57,8 @@ class Date
   end
   alias_method :default_inspect, :inspect
   alias_method :inspect, :readable_inspect
+
+  def xmlschema
+    strftime DATE_FORMATS[:xmlschema]
+  end
 end

--- a/motion/core_ext/date/conversions.rb
+++ b/motion/core_ext/date/conversions.rb
@@ -34,15 +34,13 @@ class Date
   #   Date::DATE_FORMATS[:month_and_year] = '%B %Y'
   #   Date::DATE_FORMATS[:short_ordinal] = ->(date) { date.strftime("%B #{date.day.ordinalize}") }
   def to_formatted_s(format = :default)
-    if formatter = DATE_FORMATS[format]
-      if formatter.respond_to?(:call)
-        formatter.call(self).to_s
-      else
-        strftime(formatter)
-      end
-    else
-      to_default_s
-    end
+    formatter = DATE_FORMATS[format]
+
+    return to_default_s unless formatter
+
+    return formatter.call(self).to_s if formatter.respond_to?(:call)
+
+    strftime(formatter)
   end
   alias_method :to_default_s, :to_s
   alias_method :to_s, :to_formatted_s

--- a/motion/core_ext/object/to_json.rb
+++ b/motion/core_ext/object/to_json.rb
@@ -3,12 +3,12 @@
 class Object
   # Serializes the object to a hash then the hash using Cocoa's NSJSONSerialization
   def to_json
-    attributes = {}
-
-    self.instance_variables.each do |attribute|
-      key = attribute.to_s.gsub('@', '')
-      attributes[key] = self.instance_variable_get(attribute)
-    end
+    attributes =
+      if respond_to?(:to_hash)
+        to_hash.as_json
+      else
+        instance_values.as_json
+      end
 
     attributes.to_json
   end
@@ -73,7 +73,7 @@ end
 class String
   # Returns JSON-escaped +self+.
   def to_json
-    JSONString.escape self
+    JSONString.escape(self)
   end
 end
 
@@ -88,6 +88,26 @@ class Numeric
   # Returns +self+.
   def to_json
     self
+  end
+end
+
+class Date
+  def as_json
+    strftime("%Y-%m-%d")
+  end
+
+  def to_json
+    as_json.to_json
+  end
+end
+
+class Time
+  def as_json
+    xmlschema
+  end
+
+  def to_json
+    as_json.to_json
   end
 end
 

--- a/motion/core_ext/time/conversions.rb
+++ b/motion/core_ext/time/conversions.rb
@@ -13,8 +13,29 @@ class Time
     :rfc822       => lambda { |time|
       offset_format = time.formatted_offset(false)
       time.strftime("%a, %d %b %Y %H:%M:%S #{offset_format}")
-    }
+    },
+    :iso8601      => '%Y-%m-%dT%H:%M:%SZ'
   }
+
+  # Accepts a iso8601 time string and returns a new instance of Time
+  def self.iso8601(time_string)
+    format_string = "yyyy-MM-dd'T'HH:mm:ss"
+
+    # Fractional Seconds
+    format_string += '.SSS' if time_string.include?('.')
+
+    # Zulu (standard) or with a timezone
+    format_string += time_string.include?('Z') ? "'Z'" : 'ZZZZZ'
+
+    cached_date_formatter(format_string).dateFromString(time_string)
+  end
+
+  # Returns an iso8601-compliant string
+  # This method is aliased to <tt>xmlschema</tt>.
+  def iso8601
+    utc.strftime DATE_FORMATS[:iso8601]
+  end
+  alias_method :xmlschema, :iso8601
 
   # Converts to a formatted string. See DATE_FORMATS for builtin formats.
   #
@@ -41,12 +62,28 @@ class Time
   #   Time::DATE_FORMATS[:month_and_year] = '%B %Y'
   #   Time::DATE_FORMATS[:short_ordinal]  = ->(time) { time.strftime("%B #{time.day.ordinalize}") }
   def to_formatted_s(format = :default)
-    if formatter = DATE_FORMATS[format]
-      formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)
-    else
-      to_default_s
-    end
+    return iso8601 if format == :iso8601
+
+    formatter = DATE_FORMATS[format]
+
+    return to_default_s unless formatter
+
+    return formatter.call(self).to_s if formatter.respond_to?(:call)
+
+    strftime(formatter)
   end
   alias_method :to_default_s, :to_s
   alias_method :to_s, :to_formatted_s
+
+  private
+
+  def self.cached_date_formatter(dateFormat)
+    Thread.current[:date_formatters] ||= {}
+    Thread.current[:date_formatters][dateFormat] ||=
+      NSDateFormatter.alloc.init.tap do |formatter|
+        formatter.dateFormat = dateFormat
+        formatter.timeZone   = NSTimeZone.timeZoneWithAbbreviation 'UTC'
+      end
+  end
+  private_class_method :cached_date_formatter
 end

--- a/spec/motion-support/core_ext/date/conversion_spec.rb
+++ b/spec/motion-support/core_ext/date/conversion_spec.rb
@@ -1,18 +1,61 @@
-describe "date" do
-  describe "conversions" do
-    it "should convert date to string" do
-      date = Date.new(2005, 2, 21)
-      date.to_s.should == "2005-2-21"
-      date.to_s(:short).should == "21 Feb"
-      date.to_s(:long).should == "February 21, 2005"
-      date.to_s(:long_ordinal).should == "February 21st, 2005"
-      date.to_s(:db).should == "2005-02-21"
-      date.to_s(:rfc822).should == "21 Feb 2005"
+describe 'date' do
+  describe 'conversions' do
+    before { @date = Date.new(2005, 2, 21) }
+
+    describe '#iso8601' do
+      it 'should convert to iso8601 format' do
+        @date.iso8601.should == '2005-02-21'
+      end
     end
-    
-    it "should make inspect readable" do
-      Date.new(2005, 2, 21).readable_inspect.should == "Mon, 21 Feb 2005"
-      Date.new(2005, 2, 21).readable_inspect.should == Date.new(2005, 2, 21).inspect
+
+    describe '#to_s' do
+      it 'should convert to db format by default' do
+        @date.to_s.should == '2005-2-21'
+      end
+
+      it 'should convert to short format' do
+        @date.to_s(:short).should == '21 Feb'
+      end
+
+      it 'should convert to long format' do
+        @date.to_s(:long).should == 'February 21, 2005'
+      end
+
+      it 'should convert to long_ordinal format' do
+        @date.to_s(:long_ordinal).should == 'February 21st, 2005'
+      end
+
+      it 'should convert to db format' do
+        @date.to_s(:db).should == '2005-02-21'
+      end
+
+      it 'should convert to rfc822 format' do
+        @date.to_s(:rfc822).should == '21 Feb 2005'
+      end
+
+      it 'should convert to iso8601 format' do
+        @date.to_s(:iso8601).should == '2005-02-21'
+      end
+
+      it 'should convert to xmlschema format' do
+        @date.to_s(:xmlschema).should == '2005-02-21T00:00:00Z'
+      end
+    end
+
+    describe '#readable_inspect' do
+      it 'should convert to a readable string' do
+        @date.readable_inspect.should == 'Mon, 21 Feb 2005'
+      end
+
+      it 'should also respond to #inspect' do
+        @date.readable_inspect.should == @date.inspect
+      end
+    end
+
+    describe '#xmlschema' do
+      it 'should convert to xmlschema format' do
+        @date.xmlschema.should == '2005-02-21T00:00:00Z'
+      end
     end
   end
 end

--- a/spec/motion-support/core_ext/object/to_json_spec.rb
+++ b/spec/motion-support/core_ext/object/to_json_spec.rb
@@ -36,9 +36,24 @@ describe ".to_json" do
     end
   end
 
+  describe "Time" do
+    it "should return iso8601" do
+      Time.new(2015, 12, 25, 1, 2, 3, '-05:00').utc.to_json.should == '"2015-12-25T06:02:03Z"'
+    end
+  end
+
+  describe "Date" do
+    it "should return iso8601" do
+      Date.new(2015, 12, 25).to_json.should == '"2015-12-25"'
+    end
+  end
+
   describe "array" do
     it "should convert mixed type array" do
-      [true, false, nil, {:foo => :bar}, 'fizz', ''].to_json.should == '[true,false,null,{"foo":"bar"},"fizz",""]'
+      input = [true, false, nil, {:foo => :bar}, 'fizz', '', Time.new(2015, 12, 25, 1, 2, 3, '-05:00').utc, Date.new(2015, 12, 25)]
+      output = '[true,false,null,{"foo":"bar"},"fizz","","2015-12-25T06:02:03Z","2015-12-25"]'
+
+      input.to_json.should == output
     end
   end
 


### PR DESCRIPTION
Adds `.iso8601` support to `Date` and `Time`, which is required for them to be convertible to JSON (per http://apidock.com/rails/v4.2.1/ActiveSupport/TimeWithZone/as_json)