### PR TITLE
Handle array access syntax on strings with emoji

### DIFF
--- a/spec/motion-support/core_ext/string/access_spec.rb
+++ b/spec/motion-support/core_ext/string/access_spec.rb
@@ -49,5 +49,10 @@ describe "String" do
       hash["hello123".first(5)] = true
       hash.keys.should == %w(hello)
     end
+
+    it "should handle emojis" do
+      "😊 hello"[0].should == "😊"
+      "😊 hello".last(5).should == "hello"
+    end
   end
 end


### PR DESCRIPTION
> Emojis pose a problem for array-like access of a string. If you try to
> grab one register you'll get am error: "You can't cut a surrogate in two in
> an encoding that is not UTF-16 (IndexError)"
> Calling split(''), which splits the string into array of characters, works
> correctly even with emojis. So to make this method work as expected for
> strings, first split it then join.