### PR TITLE
Fixed loading just motion-support/numeric

### DIFF
--- a/lib/motion-support/core_ext/numeric.rb
+++ b/lib/motion-support/core_ext/numeric.rb
@@ -1,6 +1,7 @@
 require 'motion-require'
 
 files = [
+  'duration',
   'core_ext/numeric/bytes',
   'core_ext/numeric/conversions',
   'core_ext/numeric/time'


### PR DESCRIPTION
Currently if you require just `motion-support/numeric` it dies because `duration` is not part of the load tree.

This adds duration to the load so that Numeric extensions work on their own.