### PR TITLE
Remove motion-require.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,4 @@
 source "http://rubygems.org"
 
-gem 'motion-require'
-
 # Specify your gem's dependencies in motion-support.gemspec
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,10 @@
 #!/usr/bin/env rake
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
+
 require 'motion/project/template/ios'
 require "bundler/gem_tasks"
-Bundler.setup
+require "bundler/setup"
 Bundler.require
 
 require 'motion-support'
@@ -10,5 +12,4 @@ require 'motion-support'
 Motion::Project::App.setup do |app|
   # Use `rake config' to see complete project settings.
   app.name = 'MotionSupport'
-  app.detect_dependencies = false
 end

--- a/lib/motion-support.rb
+++ b/lib/motion-support.rb
@@ -1,3 +1,8 @@
-require 'motion-require'
+unless defined?(Motion::Project::Config)
+  raise "This file must be required within a RubyMotion project Rakefile."
+end
 
-Motion::Require.all(Dir.glob(File.expand_path('../../motion/**/*.rb', __FILE__)))
+require 'motion-support/motion_support_files'
+Motion::Project::App.setup do |app|
+  app.files.unshift(MotionSupport.requires)
+end

--- a/lib/motion-support/callbacks.rb
+++ b/lib/motion-support/callbacks.rb
@@ -1,11 +1,4 @@
-require 'motion-require'
-
-files = [
-  "_stdlib/array",
-  "concern",
-  "descendants_tracker",
-  "callbacks",
-  "core_ext/kernel/singleton_class"
-].map { |file| File.expand_path(File.join(File.dirname(__FILE__), "/../../motion", "#{file}.rb")) }
-
-Motion::Require.all(files)
+require 'motion_support_files'
+Motion::Project::App.setup do |app|
+  app.files.unshift(MotionSupport.callbacks_files)
+end

--- a/lib/motion-support/concern.rb
+++ b/lib/motion-support/concern.rb
@@ -1,7 +1,4 @@
-require 'motion-require'
-
-files = [
-  "concern"
-].map { |file| File.expand_path(File.join(File.dirname(__FILE__), "/../../motion", "#{file}.rb")) }
-
-Motion::Require.all(files)
+require 'motion_support_files'
+Motion::Project::App.setup do |app|
+  app.files.unshift(MotionSupport.concern_files)
+end

--- a/lib/motion-support/core_ext.rb
+++ b/lib/motion-support/core_ext.rb
@@ -1,3 +1,4 @@
-Dir["#{File.dirname(__FILE__)}/core_ext/*.rb"].sort.each do |path|
-  require path
+require 'motion_support_files'
+Motion::Project::App.setup do |app|
+  app.files.unshift(MotionSupport.core_ext_files)
 end

--- a/lib/motion-support/core_ext/array.rb
+++ b/lib/motion-support/core_ext/array.rb
@@ -1,13 +1,4 @@
-require 'motion-require'
-
-files = [
-  'core_ext/array',
-  'core_ext/array/wrap',
-  'core_ext/array/access',
-  'core_ext/array/conversions',
-  'core_ext/array/extract_options',
-  'core_ext/array/grouping',
-  'core_ext/array/prepend_and_append'
-].map { |file| File.expand_path(File.join(File.dirname(__FILE__), "/../../../motion", "#{file}.rb")) }
-
-Motion::Require.all(files)
+require 'core_ext_files'
+Motion::Project::App.setup do |app|
+  app.files.unshift(MotionSupport.array_files)
+end

--- a/lib/motion-support/core_ext/class.rb
+++ b/lib/motion-support/core_ext/class.rb
@@ -1,8 +1,4 @@
-require 'motion-require'
-
-files = [
-  'core_ext/class/attribute',
-  'core_ext/class/attribute_accessors',
-].map { |file| File.expand_path(File.join(File.dirname(__FILE__), "/../../../motion", "#{file}.rb")) }
-
-Motion::Require.all(files)
+require 'core_ext_files'
+Motion::Project::App.setup do |app|
+  app.files.unshift(MotionSupport.class_files)
+end

--- a/lib/motion-support/core_ext/core_ext_files.rb
+++ b/lib/motion-support/core_ext/core_ext_files.rb
@@ -1,0 +1,128 @@
+module MotionSupport
+  class << self
+    def array_files
+      %w(
+        core_ext/array
+        core_ext/array/wrap
+        core_ext/array/access
+        core_ext/array/conversions
+        core_ext/array/extract_options
+        core_ext/array/grouping
+        core_ext/array/prepend_and_append
+      ).map { |file| self.map_core_ext_file_to_motion_dir(file) }
+    end
+    
+    def class_files
+      %w(
+        core_ext/class/attribute
+        core_ext/class/attribute_accessors
+      ).map { |file| self.map_core_ext_file_to_motion_dir(file) }
+    end
+
+    def hash_files
+      %w(
+        core_ext/ns_dictionary
+        core_ext/object/to_param
+        core_ext/hash/deep_merge
+        core_ext/hash/except
+        core_ext/hash/indifferent_access
+        core_ext/hash/keys
+        core_ext/hash/reverse_merge
+        core_ext/hash/slice
+        core_ext/hash/deep_delete_if
+        hash_with_indifferent_access
+        core_ext/module/delegation
+      ).map { |file| self.map_core_ext_file_to_motion_dir(file) }
+    end
+
+    def integer_files
+      %w(
+        core_ext/integer/multiple
+        core_ext/integer/inflections
+        core_ext/integer/time
+      ).map { |file| self.map_core_ext_file_to_motion_dir(file) }
+    end
+
+    def module_files
+      %w(
+        core_ext/module/aliasing
+        core_ext/module/introspection
+        core_ext/module/anonymous
+        core_ext/module/reachable
+        core_ext/module/attribute_accessors
+        core_ext/module/attr_internal
+        core_ext/module/delegation
+        core_ext/module/remove_method
+      ).map { |file| self.map_core_ext_file_to_motion_dir(file) }
+    end
+
+    def numeric_files
+      %w(
+        duration
+        core_ext/numeric/bytes
+        core_ext/numeric/conversions
+        core_ext/numeric/time
+      ).map { |file| self.map_core_ext_file_to_motion_dir(file) }
+    end
+
+    def object_files
+      %w(
+        _stdlib/cgi
+        core_ext/object/acts_like
+        core_ext/object/blank
+        core_ext/object/deep_dup
+        core_ext/object/duplicable
+        core_ext/object/inclusion
+        core_ext/object/try
+        core_ext/object/instance_variables
+        core_ext/object/to_json
+        core_ext/object/to_param
+        core_ext/object/to_query
+      ).map { |file| self.map_core_ext_file_to_motion_dir(file) }
+    end
+
+    def range_files
+      %w(
+        core_ext/range/include_range
+        core_ext/range/overlaps
+      ).map { |file| self.map_core_ext_file_to_motion_dir(file) }
+    end
+
+    def string_files
+      %w(
+        core_ext/ns_string
+        core_ext/string/access
+        core_ext/string/behavior
+        core_ext/string/exclude
+        core_ext/string/filters
+        core_ext/string/indent
+        core_ext/string/starts_ends_with
+        core_ext/string/inflections
+        core_ext/string/strip
+        core_ext/module/delegation
+      ).map { |file| self.map_core_ext_file_to_motion_dir(file) }
+    end
+
+    def time_files
+      %w(
+        _stdlib/date
+        _stdlib/time
+        core_ext/time/acts_like
+        core_ext/time/calculations
+        core_ext/time/conversions
+        core_ext/date/acts_like
+        core_ext/date/calculations
+        core_ext/date/conversions
+        core_ext/date_and_time/calculations
+        core_ext/integer/time
+        core_ext/numeric/time
+        core_ext/object/acts_like
+        duration
+      ).map { |file| self.map_core_ext_file_to_motion_dir(file) }
+    end
+    
+    def map_core_ext_file_to_motion_dir(file)
+      File.expand_path(File.join(File.dirname(__FILE__), "/../../../motion", "#{file}.rb"))
+    end
+  end
+end

--- a/lib/motion-support/core_ext/hash.rb
+++ b/lib/motion-support/core_ext/hash.rb
@@ -1,17 +1,4 @@
-require 'motion-require'
-
-files = [
-  'core_ext/ns_dictionary',
-  'core_ext/hash/deep_merge',
-  'core_ext/hash/except',
-  'core_ext/hash/indifferent_access',
-  'core_ext/hash/keys',
-  'core_ext/hash/reverse_merge',
-  'core_ext/hash/slice',
-  'core_ext/hash/deep_delete_if',
-  'hash_with_indifferent_access',
-  
-  'core_ext/module/delegation'
-].map { |file| File.expand_path(File.join(File.dirname(__FILE__), "/../../../motion", "#{file}.rb")) }
-
-Motion::Require.all(files)
+require 'core_ext_files'
+Motion::Project::App.setup do |app|
+  app.files.unshift(MotionSupport.hash_files)
+end

--- a/lib/motion-support/core_ext/integer.rb
+++ b/lib/motion-support/core_ext/integer.rb
@@ -1,9 +1,4 @@
-require 'motion-require'
-
-files = [
-  'core_ext/integer/multiple',
-  'core_ext/integer/inflections',
-  'core_ext/integer/time'
-].map { |file| File.expand_path(File.join(File.dirname(__FILE__), "/../../../motion", "#{file}.rb")) }
-
-Motion::Require.all(files)
+require 'core_ext_files'
+Motion::Project::App.setup do |app|
+  app.files.unshift(MotionSupport.integer_files)
+end

--- a/lib/motion-support/core_ext/module.rb
+++ b/lib/motion-support/core_ext/module.rb
@@ -1,14 +1,4 @@
-require 'motion-require'
-
-files = [
-  'core_ext/module/aliasing',
-  'core_ext/module/introspection',
-  'core_ext/module/anonymous',
-  'core_ext/module/reachable',
-  'core_ext/module/attribute_accessors',
-  'core_ext/module/attr_internal',
-  'core_ext/module/delegation',
-  'core_ext/module/remove_method'
-].map { |file| File.expand_path(File.join(File.dirname(__FILE__), "/../../../motion", "#{file}.rb")) }
-
-Motion::Require.all(files)
+require 'core_ext_files'
+Motion::Project::App.setup do |app|
+  app.files.unshift(MotionSupport.module_files)
+end

--- a/lib/motion-support/core_ext/numeric.rb
+++ b/lib/motion-support/core_ext/numeric.rb
@@ -1,10 +1,4 @@
-require 'motion-require'
-
-files = [
-  'duration',
-  'core_ext/numeric/bytes',
-  'core_ext/numeric/conversions',
-  'core_ext/numeric/time'
-].map { |file| File.expand_path(File.join(File.dirname(__FILE__), "/../../../motion", "#{file}.rb")) }
-
-Motion::Require.all(files)
+require 'core_ext_files'
+Motion::Project::App.setup do |app|
+  app.files.unshift(MotionSupport.numeric_files)
+end

--- a/lib/motion-support/core_ext/object.rb
+++ b/lib/motion-support/core_ext/object.rb
@@ -1,15 +1,4 @@
-require 'motion-require'
-
-files = [
-  '_stdlib/cgi',
-  'core_ext/object/acts_like',
-  'core_ext/object/blank',
-  'core_ext/object/deep_dup',
-  'core_ext/object/duplicable',
-  'core_ext/object/try',
-  'core_ext/object/instance_variables',
-  'core_ext/object/to_param',
-  'core_ext/object/to_query',
-].map { |file| File.expand_path(File.join(File.dirname(__FILE__), "/../../../motion", "#{file}.rb")) }
-
-Motion::Require.all(files)
+require 'core_ext_files'
+Motion::Project::App.setup do |app|
+  app.files.unshift(MotionSupport.object_files)
+end

--- a/lib/motion-support/core_ext/range.rb
+++ b/lib/motion-support/core_ext/range.rb
@@ -1,8 +1,4 @@
-require 'motion-require'
-
-files = [
-  'core_ext/range/include_range',
-  'core_ext/range/overlaps'
-].map { |file| File.expand_path(File.join(File.dirname(__FILE__), "/../../../motion", "#{file}.rb")) }
-
-Motion::Require.all(files)
+require 'core_ext_files'
+Motion::Project::App.setup do |app|
+  app.files.unshift(MotionSupport.range_files)
+end

--- a/lib/motion-support/core_ext/string.rb
+++ b/lib/motion-support/core_ext/string.rb
@@ -1,17 +1,4 @@
-require 'motion-require'
-
-files = [
-  'core_ext/ns_string',
-  'core_ext/string/access',
-  'core_ext/string/behavior',
-  'core_ext/string/exclude',
-  'core_ext/string/filters',
-  'core_ext/string/indent',
-  'core_ext/string/starts_ends_with',
-  'core_ext/string/inflections',
-  'core_ext/string/strip',
-  
-  'core_ext/module/delegation'
-].map { |file| File.expand_path(File.join(File.dirname(__FILE__), "/../../../motion", "#{file}.rb")) }
-
-Motion::Require.all(files)
+require 'core_ext_files'
+Motion::Project::App.setup do |app|
+  app.files.unshift(MotionSupport.string_files)
+end

--- a/lib/motion-support/core_ext/time.rb
+++ b/lib/motion-support/core_ext/time.rb
@@ -1,19 +1,4 @@
-require 'motion-require'
-
-files = [
-  '_stdlib/date',
-  '_stdlib/time',
-  'core_ext/time/acts_like',
-  'core_ext/time/calculations',
-  'core_ext/time/conversions',
-  'core_ext/date/acts_like',
-  'core_ext/date/calculations',
-  'core_ext/date/conversions',
-  'core_ext/date_and_time/calculations',
-  'core_ext/integer/time',
-  'core_ext/numeric/time',
-  'core_ext/object/acts_like',
-  'duration'
-].map { |file| File.expand_path(File.join(File.dirname(__FILE__), "/../../../motion", "#{file}.rb")) }
-
-Motion::Require.all(files)
+require 'core_ext_files'
+Motion::Project::App.setup do |app|
+  app.files.unshift(MotionSupport.time_files)
+end

--- a/lib/motion-support/inflector.rb
+++ b/lib/motion-support/inflector.rb
@@ -1,12 +1,4 @@
-require 'motion-require'
-
-files = [
-  "inflector/inflections",
-  "inflector/methods",
-  "inflections",
-  "core_ext/string/inflections",
-  
-  "core_ext/array/prepend_and_append"
-].map { |file| File.expand_path(File.join(File.dirname(__FILE__), "/../../motion", "#{file}.rb")) }
-
-Motion::Require.all(files)
+require 'motion_support_files'
+Motion::Project::App.setup do |app|
+  app.files.unshift(MotionSupport.inflector_files)
+end

--- a/lib/motion-support/motion_support_files.rb
+++ b/lib/motion-support/motion_support_files.rb
@@ -1,0 +1,62 @@
+require_relative 'core_ext/core_ext_files'
+module MotionSupport
+  class << self
+
+    def callbacks_files
+      %w(
+        _stdlib/array
+        concern
+        descendants_tracker
+        callbacks
+        core_ext/kernel/singleton_class
+      ).map { |file| self.map_file_to_motion_dir(file) }
+    end
+
+    def concern_files
+      ['concern'].map { |file| self.map_file_to_motion_dir(file) }
+    end
+
+    def core_ext_files
+      base_files = %w(
+        core_ext/enumerable
+        core_ext/array
+        core_ext/metaclass
+        core_ext/ns_dictionary
+        core_ext/ns_string
+        core_ext/regexp
+      ).map { |file| self.map_file_to_motion_dir(file) }
+      
+      (array_files + class_files + module_files + integer_files + hash_files +
+        numeric_files + object_files + range_files + string_files + time_files + base_files).uniq
+    end
+
+    def inflector_files
+      %w(
+        inflector/inflections
+        inflector/methods
+        inflections
+        core_ext/string/inflections
+        core_ext/array/prepend_and_append
+      ).map { |file| self.map_file_to_motion_dir(file) }
+    end
+
+    def requires
+      base_files = %w(
+        callbacks
+        concern
+        descendants_tracker
+        duration
+        hash_with_indifferent_access
+        inflections
+        logger
+        number_helper
+        version
+      ).map { |file| self.map_file_to_motion_dir(file) }
+      (callbacks_files + core_ext_files + inflector_files + base_files).uniq
+    end
+
+    def map_file_to_motion_dir(file)
+      File.expand_path(File.join(File.dirname(__FILE__), "/../../motion", "#{file}.rb"))
+    end
+  end
+end

--- a/motion-support.gemspec
+++ b/motion-support.gemspec
@@ -15,6 +15,5 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
 
-  s.add_dependency "motion-require", ">= 0.0.6"
   s.add_development_dependency 'rake'
 end

--- a/motion/callbacks.rb
+++ b/motion/callbacks.rb
@@ -1,5 +1,3 @@
-motion_require 'concern'
-
 module MotionSupport
   # Callbacks are code hooks that are run at key points in an object's lifecycle.
   # The typical use case is to have a base class define a set of callbacks

--- a/motion/core_ext/date/acts_like.rb
+++ b/motion/core_ext/date/acts_like.rb
@@ -1,5 +1,3 @@
-motion_require '../object/acts_like'
-
 class Date
   # Duck-types as a Date-like class. See Object#acts_like?.
   def acts_like_date?

--- a/motion/core_ext/date/calculations.rb
+++ b/motion/core_ext/date/calculations.rb
@@ -1,5 +1,3 @@
-motion_require "../date_and_time/calculations"
-
 class Date
   include DateAndTime::Calculations
 
@@ -77,8 +75,8 @@ class Date
       plus_without_duration(other)
     end
   end
-  alias_method :+, :plus_with_duration
   alias_method :plus_without_duration, :+
+  alias_method :+, :plus_with_duration
 
   def minus_with_duration(other) #:nodoc:
     if MotionSupport::Duration === other
@@ -87,8 +85,8 @@ class Date
       minus_without_duration(other)
     end
   end
-  alias_method :-, :minus_with_duration
   alias_method :minus_without_duration, :-
+  alias_method :-, :minus_with_duration
 
   # Provides precise Date calculations for years, months, and days. The +options+ parameter takes a hash with
   # any of these keys: <tt>:years</tt>, <tt>:months</tt>, <tt>:weeks</tt>, <tt>:days</tt>.

--- a/motion/core_ext/hash/keys.rb
+++ b/motion/core_ext/hash/keys.rb
@@ -147,4 +147,27 @@ class Hash
   def deep_symbolize_keys!
     deep_transform_keys!{ |key| key.to_sym rescue key }
   end
+
+  # Returns a string representation of the receiver suitable for use as a URL
+  # query string:
+  #
+  #   {name: 'David', nationality: 'Danish'}.to_param
+  #   # => "name=David&nationality=Danish"
+  #
+  # An optional namespace can be passed to enclose the param names:
+  #
+  #   {name: 'David', nationality: 'Danish'}.to_param('user')
+  #   # => "user[name]=David&user[nationality]=Danish"
+  #
+  # The string pairs "key=value" that conform the query string
+  # are sorted lexicographically in ascending order.
+  #
+  # This method is also aliased as +to_query+.
+  def to_param(namespace = nil)
+    collect do |key, value|
+      value.to_query(namespace ? "#{namespace}[#{key}]" : key)
+    end.sort * '&'
+  end
+  alias_method :to_query, :to_param
+  
 end

--- a/motion/core_ext/ns_dictionary.rb
+++ b/motion/core_ext/ns_dictionary.rb
@@ -1,5 +1,3 @@
-motion_require "module/delegation"
-
 class NSDictionary
   def to_hash
     Hash.new.tap do |h|

--- a/motion/core_ext/ns_string.rb
+++ b/motion/core_ext/ns_string.rb
@@ -1,5 +1,3 @@
-motion_require "module/delegation"
-
 class NSString
   def to_s
     String.new(self)

--- a/motion/core_ext/object/to_param.rb
+++ b/motion/core_ext/object/to_param.rb
@@ -33,26 +33,3 @@ class Array
     collect { |e| e.to_param }.join '/'
   end
 end
-
-class Hash
-  # Returns a string representation of the receiver suitable for use as a URL
-  # query string:
-  #
-  #   {name: 'David', nationality: 'Danish'}.to_param
-  #   # => "name=David&nationality=Danish"
-  #
-  # An optional namespace can be passed to enclose the param names:
-  #
-  #   {name: 'David', nationality: 'Danish'}.to_param('user')
-  #   # => "user[name]=David&user[nationality]=Danish"
-  #
-  # The string pairs "key=value" that conform the query string
-  # are sorted lexicographically in ascending order.
-  #
-  # This method is also aliased as +to_query+.
-  def to_param(namespace = nil)
-    collect do |key, value|
-      value.to_query(namespace ? "#{namespace}[#{key}]" : key)
-    end.sort * '&'
-  end
-end

--- a/motion/core_ext/object/to_query.rb
+++ b/motion/core_ext/object/to_query.rb
@@ -1,5 +1,3 @@
-motion_require 'to_param'
-
 class Object
   # Converts an object into a string suitable for use as a URL query string, using the given <tt>key</tt> as the
   # param name.
@@ -21,6 +19,3 @@ class Array
   end
 end
 
-class Hash
-  alias_method :to_query, :to_param
-end

--- a/motion/core_ext/range/include_range.rb
+++ b/motion/core_ext/range/include_range.rb
@@ -1,5 +1,3 @@
-motion_require "../module/aliasing"
-
 class Range
   # Extends the default Range#include? to support range comparisons.
   #  (1..5).include?(1..5) # => true

--- a/motion/core_ext/time/acts_like.rb
+++ b/motion/core_ext/time/acts_like.rb
@@ -1,5 +1,3 @@
-motion_require '../object/acts_like'
-
 class Time
   # Duck-types as a Time-like class. See Object#acts_like?.
   def acts_like_time?

--- a/motion/core_ext/time/calculations.rb
+++ b/motion/core_ext/time/calculations.rb
@@ -1,5 +1,3 @@
-motion_require "../date_and_time/calculations"
-
 class Time
   include DateAndTime::Calculations
 

--- a/motion/hash_with_indifferent_access.rb
+++ b/motion/hash_with_indifferent_access.rb
@@ -1,5 +1,3 @@
-motion_require 'core_ext/hash/keys'
-
 module MotionSupport
   # Implements a hash where keys <tt>:foo</tt> and <tt>"foo"</tt> are considered
   # to be the same.

--- a/motion/inflections.rb
+++ b/motion/inflections.rb
@@ -1,5 +1,3 @@
-motion_require 'inflector/inflections'
-
 module MotionSupport
   Inflector.inflections do |inflect|
     inflect.plural(/$/, 's')

--- a/motion/inflector/inflections.rb
+++ b/motion/inflector/inflections.rb
@@ -1,5 +1,3 @@
-motion_require '../core_ext/array/prepend_and_append'
-
 module MotionSupport
   module Inflector
     extend self

--- a/spec/motion-support/core_ext/date/calculation_spec.rb
+++ b/spec/motion-support/core_ext/date/calculation_spec.rb
@@ -182,5 +182,13 @@ describe "Date" do
         Date.yesterday.should.not.be.future
       end
     end
+
+    describe "plus_with_duration" do
+      it "should calculate correctly" do
+        (Date.new(1982,10,4) + 1.day).should == Date.new(1982,10,5)
+        (Date.new(1982,10,4) + 1.month).should == Date.new(1982,11,4)
+        (Date.new(1982,10,4) + 1.year).should == Date.new(1983,10,4)
+      end
+    end
   end
 end

--- a/spec/motion-support/core_ext/object/duplicable_spec.rb
+++ b/spec/motion-support/core_ext/object/duplicable_spec.rb
@@ -1,6 +1,6 @@
 describe "duplicable?" do
   before do
-    @raise_dup = [nil, false, true, :symbol, 1, 2.3, 5.seconds, BigDecimal.new('4.56')]
+    @raise_dup = [nil, false, true]
     @yes = ['1', Object.new, /foo/, [], {}, Time.now, Class.new, Module.new]
     @no = []
   end

--- a/spec/motion-support/descendants_tracker_spec.rb
+++ b/spec/motion-support/descendants_tracker_spec.rb
@@ -18,7 +18,7 @@ module DescendantsTrackerSpec
   ALL = [Parent, Child1, Child2, Grandchild1, Grandchild2]
 end
 
-describe "DescendatsTracker" do
+describe "DescendantsTracker" do
   describe "descendants" do
     it "should get all descendants from parent class" do
       [DescendantsTrackerSpec::Child1, DescendantsTrackerSpec::Child2, DescendantsTrackerSpec::Grandchild1, DescendantsTrackerSpec::Grandchild2].should == DescendantsTrackerSpec::Parent.descendants


### PR DESCRIPTION
This is a 🤞 final fix for [Issue 38](https://github.com/rubymotion/motion-support/issues/38), which will make motion-support work properly on High Sierra.

Main feature: rips motion-require out by the roots, and manages class loading/compilation order to 1) make it all work and 2) remove cyclical dependencies. 

Minor updates:
- update Rakefile for current RubyMotion
- fix a couple types
- fix a build error
- adds a spec for plus_with_duration (+), which would have broken with the previous "fixes" that just commented out the broken bits.